### PR TITLE
fix(src/include/gxinvoke.h): fix linkage scope

### DIFF
--- a/src/include/gxinvoke.h
+++ b/src/include/gxinvoke.h
@@ -62,9 +62,9 @@ extern "C" {
         gxValueEventArg* e);
 #endif //DLMS_IGNORE_SCRIPT_TABLE
 
+#endif //DLMS_IGNORE_SERVER
 #ifdef  __cplusplus
 }
 #endif
-#endif //DLMS_IGNORE_SERVER
 
 #endif //COSEM_INVOKE_H


### PR DESCRIPTION
Fixed overlap between linkage scope and `DLMS_SERVER_IGNORE` switch
